### PR TITLE
Add github actions

### DIFF
--- a/.github/workflows/push-actions.yml
+++ b/.github/workflows/push-actions.yml
@@ -1,0 +1,10 @@
+name: push-actions
+on: [push]
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install -e .
+      - run: python -m pytest --cov mascado tests

--- a/.github/workflows/push-actions.yml
+++ b/.github/workflows/push-actions.yml
@@ -7,4 +7,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - run: pip install -e .
+      - run: pip install pytest pytest-cov
       - run: python -m pytest --cov mascado tests


### PR DESCRIPTION
Add github actions continuous integration.

This will run the tests, with coverage, on each commit, which will also show in pull requests.